### PR TITLE
Compare subtask verdict with expected when invoking solution

### DIFF
--- a/scripts/internal/invoke.py
+++ b/scripts/internal/invoke.py
@@ -10,14 +10,40 @@ import tests_util as tu
 INTERNALS_DIR = os.environ.get('INTERNALS')
 LOGS_DIR = os.environ.get('LOGS_DIR')
 SUBTASKS_JSON = os.environ.get('SUBTASKS_JSON')
+SOLUTIONS_JSON = os.environ.get('SOLUTIONS_JSON')
 SPECIFIC_TESTS = get_bool_environ('SPECIFIC_TESTS')
 SPECIFIED_TESTS_PATTERN = os.environ.get('SPECIFIED_TESTS_PATTERN')
 
 
+def is_verdict_expected(score, verdict, expected_verdict):
+    if expected_verdict in ["correct", "model_solution"]:
+        return verdict == "Correct" and score == 1
+    elif expected_verdict == "time_limit":
+        return verdict == "Time Limit Exceeded"
+    elif expected_verdict == "memory_limit":
+        return verdict == "Runtime Error"
+    elif expected_verdict == "incorrect":
+        return verdict == "Wrong Answer"
+    elif expected_verdict == "runtime_error":
+        return verdict == "Runtime Error"
+    elif expected_verdict == "failed":
+        return verdict != "Correct" or score == 0
+    elif expected_verdict == "time_limit_and_runtime_error":
+        return verdict in ["Time Limit Exceeded", "Runtime Error"]
+    elif expected_verdict == "partially_correct":
+        return 0 < score < 1
+    else:
+        raise ValueError("Invalid verdict")
+
+
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        simple_usage_message("<tests-dir>")
+    if len(sys.argv) != 3:
+        simple_usage_message("<tests-dir> <solution-path>")
     tests_dir = sys.argv[1]
+    solution_filename = os.path.basename(sys.argv[2])
+
+    solutions_data = dict(load_json(SOLUTIONS_JSON))
+    solution_data = solutions_data.get(solution_filename, None)
 
     try:
         test_name_list = tu.get_test_names_from_tests_dir(tests_dir)
@@ -75,6 +101,20 @@ if __name__ == '__main__':
             wait_process_success(subprocess.Popen(command))
         else:
             subtask_score = subtask_result[0] * subtasks_data[subtask]['score']
+
+            expected_verdict = None
+            if solution_data is not None:
+                expected_verdict = solution_data.get("verdict", None)
+                if "except" in solution_data:
+                    expected_verdict = solution_data["except"].get(subtask, expected_verdict)
+
+            expected_verdict_args = []
+            if expected_verdict is not None:
+                if is_verdict_expected(subtask_result[0], subtask_result[1], expected_verdict):
+                    expected_verdict_args = ["match with expected"]
+                else:
+                    expected_verdict_args = ["expected: {}".format(expected_verdict)]
+            
             command = [
                 'bash',
                 os.path.join(INTERNALS_DIR, 'subtask_summary.sh'),
@@ -85,7 +125,7 @@ if __name__ == '__main__':
                 str(subtasks_data[subtask]['score']),
                 subtask_result[1],
                 subtask_result[2]
-            ]
+            ] + expected_verdict_args
             wait_process_success(subprocess.Popen(command))
 
             total_points += subtask_score

--- a/scripts/internal/subtask_summary.sh
+++ b/scripts/internal/subtask_summary.sh
@@ -35,6 +35,19 @@ if [ $# -gt 0 ]; then
     subtask_score_color="warn"
   fi
   boxed_echo "${subtask_score_color}" "${subtask_score}/${full_subtask_score} pts"
+
+  if [ $# -gt 0 ]; then    
+    expected_verdict_message="$1"; shift
+
+    hspace 2
+    export BOX_PADDING=30
+    expected_verdict_message_color="fail"
+    if [ "${expected_verdict_message}" == "match with expected" ]; then
+      expected_verdict_message_color="ok"
+    fi
+    boxed_echo "${expected_verdict_message_color}" "${expected_verdict_message}"
+  fi
+
   hspace 2
   echo "${test_name}"
 else

--- a/scripts/internal/util.sh
+++ b/scripts/internal/util.sh
@@ -189,6 +189,18 @@ function echo_verdict {
 	boxed_echo "${color}" "${verdict}"
 }
 
+function echo_expected_verdict_message {
+	expected_verdict_message="$1"
+
+	case "${expected_verdict_message}" in
+		"match with expected") color=ok ;;
+		*expected) color=error ;;
+		*) color=other ;;
+	esac
+
+	boxed_echo "${color}" "${expected_verdict_message}"
+}
+
 function test_score_file {
 	local test_name="$1"
 	echo "${LOGS_DIR}/${test_name}.score"

--- a/scripts/invoke.sh
+++ b/scripts/invoke.sh
@@ -190,7 +190,7 @@ if "${HAS_CHECKER}"; then
 fi
 
 ret=0
-"${PYTHON}" "${INTERNALS}/invoke.py" "${tests_dir}" || ret=$?
+"${PYTHON}" "${INTERNALS}/invoke.py" "${tests_dir}" "${solution}" || ret=$?
 
 
 echo


### PR DESCRIPTION
Example output when running tps invoke solution/solution-B_i-equals-i.cpp on https://github.com/ioi-2022/toki-cms-contest/tree/master/partition

```
solution            compile[OK]
checker             compile[OK]
0-01                sol[OK]    0.160     check[OK]       1  [Correct]             
0-02                sol[OK]    0.035     check[OK]       1  [Correct]             
smallest-case-01    sol[OK]    0.041     check[OK]       1  [Correct]             
must-jump-X_equals-one-01sol[OK]    0.134     check[OK]       1  [Correct]             
must-use-binary-search-X_equals-one-01sol[OK]    0.125     check[OK]       0  [Wrong Answer]        
must-memoize-answer-X-equals-one-01sol[OK]    0.125     check[OK]       1  [Correct]             
X-Y-equals-one-01   sol[OK]    0.615     check[OK]       0  [Wrong Answer]        
X-Y-equals-one-02   sol[OK]    0.168     check[OK]       1  [Correct]             
1-01                sol[OK]    0.226     check[OK]       1  [Correct]             
1-02                sol[OK]    0.206     check[OK]       1  [Correct]             
2-01                sol[OK]    0.081     check[OK]       0  [Wrong Answer]        
2-02                sol[OK]    0.096     check[OK]       0  [Wrong Answer]        
2-03                sol[OK]    0.057     check[OK]       1  [Correct]             
2-04                sol[OK]    0.076     check[OK]       1  [Correct]             
2-05                sol[OK]    0.073     check[OK]       1  [Correct]             
3-01                sol[OK]    0.192     check[OK]       1  [Correct]             
3-02                sol[OK]    0.165     check[OK]       0  [Wrong Answer]        
4-01                sol[OK]    0.134     check[OK]       0  [Wrong Answer]        
4-02                sol[OK]    0.131     check[OK]       1  [Correct]             
5-01                sol[OK]    0.137     check[OK]       0  [Wrong Answer]        
5-02                sol[OK]    0.079     check[OK]       0  [Wrong Answer]        
5-03                sol[OK]    0.088     check[OK]       0  [Wrong Answer]        
5-04                sol[OK]    0.126     check[OK]       0  [Wrong Answer]        
5-05                sol[OK]    0.200     check[OK]       0  [Wrong Answer]        
5-06                sol[OK]    0.374     check[OK]       1  [Correct]             

Subtask summary
samples             [2/2 tests]    [Correct]             [0/0 pts]      [match with expected]             0-01
B_i-equals-i        [4/4 tests]    [Correct]             [9/9 pts]      [match with expected]             1-01
Q-less-than-five    [8/8 tests]    [Wrong Answer]        [0/14 pts]     [match with expected]             2-01
Y-equals-one        [6/6 tests]    [Wrong Answer]        [0/22 pts]     [match with expected]             3-02
X-equals-one        [8/8 tests]    [Wrong Answer]        [0/31 pts]     [match with expected]             4-01
full                [25/25 tests]  [Wrong Answer]        [0/24 pts]     [match with expected]             2-01
9/100 pts

Finished.
```

Based on https://github.com/ioi-2022/tps/pull/9
Resolve https://github.com/ioi-2022/tps/issues/7