### PR TITLE
Refine invoke summary output and add invoke-all command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -190,7 +190,7 @@ It contains all solutions that are prepared and used in development of the task,
 
 ## solutions.json
 
-This file specifies the verdict of each solution. It is used by the web-interface to check if the behavior of each solution is expected on the test data. The verdicts can be `correct`, `time_limit`, `memory_limit`, `incorrect`, `runtime_error`, `failed`, `time_limit_and_runtime_error`, `partially_correct`.
+This file specifies the verdict of each solution. It is used by the web-interface and `invoke` to check if the behavior of each solution is expected on the test data. The verdicts can be `correct`, `time_limit`, `memory_limit`, `incorrect`, `runtime_error`, `failed`, `time_limit_and_runtime_error`, `partially_correct`.
 There is also a special verdict `model_solution` which should be used exactly once.
 The model solution is used to generate the correct outputs for test data.
 Below is an example:
@@ -558,7 +558,8 @@ Here are some notes/features on this command:
 ## invoke
 
 This command is used to compile a solution and the checker, 
-  run the solution over the test data (with the problem constraints, e.g. time limit) and check its output. 
+  run the solution over the test data (with the problem constraints, e.g. time limit) and check its output.
+If the filename exists in `solutions.json`, it will also compare the invocation verdict with the expected verdict.
 Here is the usage:
 
 ```
@@ -620,6 +621,16 @@ Here are some notes/features on this command:
 * In addition to the verdict,
    the running time and the score of the solution is printed for each test case.
   The score is usually zero or one, unless the verdict is `Partially Correct`.
+
+
+## invoke-all
+
+This command runs `invoke` for all solutions specified in `solutions.json`.
+
+All of the `invoke` command options are supported, except the following commands:
+* `-r, --show-reason`
+* `--no-check`
+* `--no-sol-compile`
 
 
 ## make-public

--- a/scripts/internal/invoke.py
+++ b/scripts/internal/invoke.py
@@ -4,6 +4,7 @@ import subprocess
 
 from util import get_bool_environ, load_json, simple_usage_message, wait_process_success
 from color_util import cprint, cprinterr, colors
+from invoke_util import get_short_verdict, is_verdict_expected
 import tests_util as tu
 
 
@@ -14,44 +15,6 @@ SOLUTIONS_JSON = os.environ.get('SOLUTIONS_JSON')
 SPECIFIC_TESTS = get_bool_environ('SPECIFIC_TESTS')
 SPECIFIED_TESTS_PATTERN = os.environ.get('SPECIFIED_TESTS_PATTERN')
 SKIP_CHECK = get_bool_environ('SKIP_CHECK')
-
-
-def get_short_verdict(verdict):
-    if verdict == "Correct":
-        return "AC"
-    elif verdict == "Runtime Error":
-        return "RTE"
-    elif verdict == "Time Limit Exceeded":
-        return "TLE"
-    elif verdict == "Wrong Answer":
-        return "WA"
-    elif verdict == "Partially Correct":
-        return "OK"
-    elif verdict == "Protocol Violation":
-        return "PV"
-    else:
-        return "JE"
-
-
-def is_verdict_expected(score, verdict, expected_verdict):
-    if expected_verdict in ["correct", "model_solution"]:
-        return verdict == "Correct" and score == 1
-    elif expected_verdict == "time_limit":
-        return verdict == "Time Limit Exceeded"
-    elif expected_verdict == "memory_limit":
-        return verdict == "Runtime Error"
-    elif expected_verdict == "incorrect":
-        return verdict == "Wrong Answer"
-    elif expected_verdict == "runtime_error":
-        return verdict == "Runtime Error"
-    elif expected_verdict == "failed":
-        return verdict != "Correct" or score == 0
-    elif expected_verdict == "time_limit_and_runtime_error":
-        return verdict in ["Time Limit Exceeded", "Runtime Error"]
-    elif expected_verdict == "partially_correct":
-        return 0 < score < 1
-    else:
-        raise ValueError("Invalid verdict")
 
 
 if __name__ == '__main__':
@@ -96,7 +59,7 @@ if __name__ == '__main__':
     subtasks_data = dict(load_json(SUBTASKS_JSON))['subtasks']
     total_points = total_full_points = 0
     unmatched_verdicts = []
-    for subtask, tests in tu.get_subtasks_tests_dict_from_tests_dir(tests_dir).items():
+    for subtask_index, (subtask, tests) in enumerate(tu.get_subtasks_tests_dict_from_tests_dir(tests_dir).items()):
         subtask_result = None
         max_execution_time = None
         testcases_run = 0
@@ -128,6 +91,7 @@ if __name__ == '__main__':
             command = [
                 'bash',
                 os.path.join(INTERNALS_DIR, 'subtask_summary.sh'),
+                str(subtask_index),
                 subtask,
                 str(len(tests))
             ]
@@ -136,6 +100,7 @@ if __name__ == '__main__':
             command = [
                 'bash',
                 os.path.join(INTERNALS_DIR, 'subtask_summary.sh'),
+                str(subtask_index),
                 subtask,
                 str(len(tests)),
                 str(testcases_run),
@@ -165,6 +130,7 @@ if __name__ == '__main__':
             command = [
                 'bash',
                 os.path.join(INTERNALS_DIR, 'subtask_summary.sh'),
+                str(subtask_index),
                 subtask,
                 str(len(tests)),
                 str(testcases_run),

--- a/scripts/internal/invoke.py
+++ b/scripts/internal/invoke.py
@@ -13,6 +13,24 @@ SUBTASKS_JSON = os.environ.get('SUBTASKS_JSON')
 SOLUTIONS_JSON = os.environ.get('SOLUTIONS_JSON')
 SPECIFIC_TESTS = get_bool_environ('SPECIFIC_TESTS')
 SPECIFIED_TESTS_PATTERN = os.environ.get('SPECIFIED_TESTS_PATTERN')
+SKIP_CHECK = get_bool_environ('SKIP_CHECK')
+
+
+def get_short_verdict(verdict):
+    if verdict == "Correct":
+        return "AC"
+    elif verdict == "Runtime Error":
+        return "RTE"
+    elif verdict == "Time Limit Exceeded":
+        return "TLE"
+    elif verdict == "Wrong Answer":
+        return "WA"
+    elif verdict == "Partially Correct":
+        return "OK"
+    elif verdict == "Protocol Violation":
+        return "PV"
+    else:
+        return "JE"
 
 
 def is_verdict_expected(score, verdict, expected_verdict):
@@ -69,29 +87,44 @@ if __name__ == '__main__':
         ]
         wait_process_success(subprocess.Popen(command))
 
-    print("\nSubtask summary")
+    print()
+    print("Subtask summary")
+
+    if solution_data is None:
+        cprint(colors.WARN, "Solution does not exist in solutions.json. Skipped checking verdict")
 
     subtasks_data = dict(load_json(SUBTASKS_JSON))['subtasks']
     total_points = total_full_points = 0
+    unmatched_verdicts = []
     for subtask, tests in tu.get_subtasks_tests_dict_from_tests_dir(tests_dir).items():
         subtask_result = None
+        max_execution_time = None
         testcases_run = 0
 
         for test in tests:
-            score = verdict = None
+            score = verdict = execution_time = None
+            if not SKIP_CHECK:
+                try:
+                    with open(os.path.join(LOGS_DIR, "{}.score".format(test)), 'r') as sf:
+                        score = float(sf.readlines()[0].strip('\n'))
+                    with open(os.path.join(LOGS_DIR, "{}.verdict".format(test)), 'r') as vf:
+                        verdict = vf.readlines()[0].strip('\n')
+                except FileNotFoundError:
+                    pass
+                else:
+                    if subtask_result is None or score < subtask_result[0]:
+                        subtask_result = (score, verdict, test)
             try:
-                with open(os.path.join(LOGS_DIR, "{}.score".format(test)), 'r') as sf:
-                    score = float(sf.readlines()[0].strip('\n'))
-                with open(os.path.join(LOGS_DIR, "{}.verdict".format(test)), 'r') as vf:
-                    verdict = vf.readlines()[0].strip('\n')
+                with open(os.path.join(LOGS_DIR, "{}.time".format(test)), 'r') as tf:
+                    execution_time = float(tf.readlines()[0].strip('\n'))
             except FileNotFoundError:
                 pass
             else:
-                if subtask_result is None or score < subtask_result[0]:
-                    subtask_result = (score, verdict, test)
+                if max_execution_time is None or max_execution_time < execution_time:
+                    max_execution_time = execution_time
                 testcases_run += 1
 
-        if subtask_result is None:
+        if max_execution_time is None:
             command = [
                 'bash',
                 os.path.join(INTERNALS_DIR, 'subtask_summary.sh'),
@@ -99,21 +132,35 @@ if __name__ == '__main__':
                 str(len(tests))
             ]
             wait_process_success(subprocess.Popen(command))
+        elif subtask_result is None:
+            command = [
+                'bash',
+                os.path.join(INTERNALS_DIR, 'subtask_summary.sh'),
+                subtask,
+                str(len(tests)),
+                str(testcases_run),
+                str(max_execution_time)
+            ]
+            wait_process_success(subprocess.Popen(command))
         else:
             subtask_score = subtask_result[0] * subtasks_data[subtask]['score']
 
-            expected_verdict = None
+            short_verdict_color = "warn"
             if solution_data is not None:
                 expected_verdict = solution_data.get("verdict", None)
                 if "except" in solution_data:
                     expected_verdict = solution_data["except"].get(subtask, expected_verdict)
-
-            expected_verdict_args = []
-            if expected_verdict is not None:
                 if is_verdict_expected(subtask_result[0], subtask_result[1], expected_verdict):
-                    expected_verdict_args = ["match with expected"]
+                    short_verdict_color = "ok"
                 else:
-                    expected_verdict_args = ["expected: {}".format(expected_verdict)]
+                    short_verdict_color = "fail"
+                    unmatched_verdicts.append((subtask, subtask_result[1], expected_verdict))
+
+            subtask_score_color = "ok"
+            if subtask_result[0] == 0:
+                subtask_score_color = "fail"
+            elif subtask_result[0] < 1:
+                subtask_score_color = "warn"
             
             command = [
                 'bash',
@@ -121,22 +168,34 @@ if __name__ == '__main__':
                 subtask,
                 str(len(tests)),
                 str(testcases_run),
+                str(max_execution_time),
+                get_short_verdict(subtask_result[1]),
+                short_verdict_color,
                 '{:g}'.format(round(subtask_score, 2)),
+                subtask_score_color,
                 str(subtasks_data[subtask]['score']),
-                subtask_result[1],
                 subtask_result[2]
-            ] + expected_verdict_args
+            ]
             wait_process_success(subprocess.Popen(command))
 
             total_points += subtask_score
             total_full_points += subtasks_data[subtask]['score']
 
-    color = colors.OK
-    if total_points == 0:
-        color = colors.ERROR
-    elif total_points < total_full_points:
-        color = colors.WARN
-    cprint(color, "{:g}/{} pts".format(round(total_points, 2), total_full_points))
+    if not SKIP_CHECK:
+        color = colors.OK
+        if total_points == 0:
+            color = colors.ERROR
+        elif total_points < total_full_points:
+            color = colors.WARN
+        cprint(color, "{:g}/{} pts".format(round(total_points, 2), total_full_points))
+
+        if solution_data is not None:
+            if len(unmatched_verdicts) == 0:
+                cprint(colors.OK, "All verdict matches with solutions.json")
+            else:
+                cprint(colors.FAIL, "Found one or more subtasks mismatch with solutions.json")
+                for subtask, verdict, expected_verdict in unmatched_verdicts:
+                    print("[{}] got '{}', expected '{}'".format(subtask, verdict, expected_verdict))
 
     if missing_tests:
         cprinterr(colors.WARN, "Missing {} {}!".format(len(missing_tests), "tests" if len(missing_tests) != 1 else "test"))

--- a/scripts/internal/invoke_all.py
+++ b/scripts/internal/invoke_all.py
@@ -138,7 +138,7 @@ if __name__ == '__main__':
     else:
         cprint(colors.FAIL, "Found one or more subtasks mismatch with solutions.json")
         for solution_filename, subtask, verdict, expected_verdict in unmatched_verdicts:
-            print("[{}] subtask '{}': got '{}', expected '{}'".format(solution_filename, subtask, verdict, expected_verdict))
+            print("{:40}: got {:20}, expected '{}'".format("[{}] subtask '{}'".format(solution_filename, subtask), "'{}'".format(verdict), expected_verdict))
 
     if missing_tests:
         cprinterr(colors.WARN, "Missing {} {}!".format(len(missing_tests), "tests" if len(missing_tests) != 1 else "test"))

--- a/scripts/internal/invoke_all.py
+++ b/scripts/internal/invoke_all.py
@@ -1,0 +1,144 @@
+import sys
+import os
+import subprocess
+
+from util import get_bool_environ, load_json, simple_usage_message, wait_process_success
+from color_util import cprint, cprinterr, colors
+from invoke_util import get_short_verdict, is_verdict_expected
+import tests_util as tu
+
+
+INTERNALS_DIR = os.environ.get('INTERNALS')
+LOGS_DIR = os.environ.get('LOGS_DIR')
+SUBTASKS_JSON = os.environ.get('SUBTASKS_JSON')
+SOLUTIONS_JSON = os.environ.get('SOLUTIONS_JSON')
+SPECIFIC_TESTS = get_bool_environ('SPECIFIC_TESTS')
+SPECIFIED_TESTS_PATTERN = os.environ.get('SPECIFIED_TESTS_PATTERN')
+SOLUTION_DIR = os.environ.get('SOLUTION_DIR')
+SKIP_CHECK = False
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        simple_usage_message("<tests-dir>")
+    tests_dir = sys.argv[1]
+
+    try:
+        test_name_list = tu.get_test_names_from_tests_dir(tests_dir)
+    except tu.MalformedTestsException as e:
+        cprinterr(colors.ERROR, "Error:")
+        sys.stderr.write("{}\n".format(e))
+        sys.exit(4)
+
+    if SPECIFIC_TESTS:
+        tu.check_pattern_exists_in_test_names(SPECIFIED_TESTS_PATTERN, test_name_list)
+        test_name_list = tu.filter_test_names_by_pattern(test_name_list, SPECIFIED_TESTS_PATTERN)
+
+    available_tests, missing_tests = tu.divide_tests_by_availability(test_name_list, tests_dir)
+    if missing_tests:
+        cprinterr(colors.WARN, "Missing tests: "+(", ".join(missing_tests)))
+
+    subtasks_tests_dict = tu.get_subtasks_tests_dict_from_tests_dir(tests_dir)
+    
+    print("Subtask summary")
+    header_line = "%-30s %-5s" % ("Filename", "Pts")
+    for subtask_index, (subtask, tests) in enumerate(subtasks_tests_dict.items()):
+        num_available_tests = len(set(tests).intersection(set(available_tests)))
+        command = [
+            'bash',
+            os.path.join(INTERNALS_DIR, 'subtask_summary.sh'),
+            str(subtask_index),
+            subtask,
+            str(len(tests)),
+            str(num_available_tests)
+        ]
+        wait_process_success(subprocess.Popen(command))
+
+        if num_available_tests > 0:
+            header_line += " %-11s" % "[{}]".format(subtask_index)
+
+    print()
+    print("Run result")
+    print(header_line)
+
+    subtasks_data = dict(load_json(SUBTASKS_JSON))['subtasks']
+    solutions_data = dict(load_json(SOLUTIONS_JSON))
+    unmatched_verdicts = []
+    for solution_filename, solution_data in solutions_data.items():
+        command = [
+            'bash',
+            os.path.join(INTERNALS_DIR, 'compile_solution.sh'),
+            os.path.join(SOLUTION_DIR, solution_filename)
+        ]
+        ret = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).wait()
+        if ret != 0:
+            cprint(colors.FAIL, "{} does not compile".format(solution_filename))
+
+        for test_name in available_tests:
+            command = [
+                'bash',
+                os.path.join(INTERNALS_DIR, 'invoke_test.sh'),
+                tests_dir,
+                test_name,
+            ]
+            wait_process_success(subprocess.Popen(command))
+
+        total_points = 0
+        solution_summary_data = []
+        for subtask_index, (subtask, tests) in enumerate(subtasks_tests_dict.items()):
+            subtask_result = None
+            max_execution_time = None
+
+            for test in tests:
+                score = verdict = execution_time = None
+                try:
+                    with open(os.path.join(LOGS_DIR, "{}.score".format(test)), 'r') as sf:
+                        score = float(sf.readlines()[0].strip('\n'))
+                    with open(os.path.join(LOGS_DIR, "{}.verdict".format(test)), 'r') as vf:
+                        verdict = vf.readlines()[0].strip('\n')
+                    with open(os.path.join(LOGS_DIR, "{}.time".format(test)), 'r') as tf:
+                        execution_time = float(tf.readlines()[0].strip('\n'))
+                except FileNotFoundError:
+                    pass
+                else:
+                    if subtask_result is None or score < subtask_result[0]:
+                        subtask_result = (score, verdict, test)
+                    if max_execution_time is None or max_execution_time < execution_time:
+                        max_execution_time = execution_time
+
+            if subtask_result is not None:
+                subtask_score = subtask_result[0] * subtasks_data[subtask]['score']
+                
+                short_verdict_color = "ok"
+                expected_verdict = solution_data.get("verdict", None)
+                if "except" in solution_data:
+                    expected_verdict = solution_data["except"].get(subtask, expected_verdict)
+                if is_verdict_expected(subtask_result[0], subtask_result[1], expected_verdict):
+                    short_verdict_color = "ok"
+                else:
+                    short_verdict_color = "fail"
+                    unmatched_verdicts.append((solution_filename, subtask, subtask_result[1], expected_verdict))
+
+                solution_summary_data.append(get_short_verdict(subtask_result[1]))
+                solution_summary_data.append(short_verdict_color)
+                solution_summary_data.append(str(max_execution_time))
+
+                total_points += subtask_score
+
+        command = [
+            'bash',
+            os.path.join(INTERNALS_DIR, 'solution_summary.sh'),
+            solution_filename,
+            '{:g}'.format(round(total_points, 2)),
+        ] + solution_summary_data
+        wait_process_success(subprocess.Popen(command))
+
+    if len(unmatched_verdicts) == 0:
+        cprint(colors.OK, "All verdict matches with solutions.json")
+    else:
+        cprint(colors.FAIL, "Found one or more subtasks mismatch with solutions.json")
+        for solution_filename, subtask, verdict, expected_verdict in unmatched_verdicts:
+            print("[{}] subtask '{}': got '{}', expected '{}'".format(solution_filename, subtask, verdict, expected_verdict))
+
+    if missing_tests:
+        cprinterr(colors.WARN, "Missing {} {}!".format(len(missing_tests), "tests" if len(missing_tests) != 1 else "test"))

--- a/scripts/internal/invoke_test.sh
+++ b/scripts/internal/invoke_test.sh
@@ -125,6 +125,7 @@ fi
 
 echo "${score}" > "${LOGS_DIR}/${test_name}.score"
 echo "${verdict}" > "${LOGS_DIR}/${test_name}.verdict"
+echo "${execution_time}" > "${LOGS_DIR}/${test_name}.time"
 
 echo
 

--- a/scripts/internal/invoke_test.sh
+++ b/scripts/internal/invoke_test.sh
@@ -21,8 +21,9 @@ function run_checker {
 	bash "${TEMPLATES}/check_test.sh" "${test_name}" "${input}" "${judge_answer}" "${sol_stdout}" "${sol_stderr}"
 }
 
-
-printf "%-${STATUS_PAD}s" "${test_name}"
+if "${VERBOSE_INVOKE}"; then
+	printf "%-${STATUS_PAD}s" "${test_name}"
+fi
 
 failed_jobs=""
 final_ret=0
@@ -42,7 +43,9 @@ fi
 
 export BOX_PADDING=4
 
-echo -n "sol"
+if "${VERBOSE_INVOKE}"; then
+	echo -n "sol"
+fi
 sol_job="${test_name}.sol"
 execution_time=""
 
@@ -71,14 +74,18 @@ if ! is_in "${input_status}" "FAIL" "SKIP"; then
 fi
 
 sol_status="$(job_status ${sol_job})"
-echo_status "${sol_status}"
-printf "%7s" "${execution_time}"
-hspace 5
+if "${VERBOSE_INVOKE}"; then
+	echo_status "${sol_status}"
+	printf "%7s" "${execution_time}"
+	hspace 5
+fi
 
 
 export BOX_PADDING=5
 
-echo -n "check"
+if "${VERBOSE_INVOKE}"; then
+	echo -n "check"
+fi
 check_job="${test_name}.check"
 
 if ! is_in "${sol_status}" "FAIL" "SKIP"; then
@@ -109,25 +116,26 @@ if ! is_in "${sol_status}" "FAIL" "SKIP"; then
 	fi
 fi
 
-check_status=$(job_status "${check_job}")
-echo_status "${check_status}"
+if "${VERBOSE_INVOKE}"; then
+	check_status=$(job_status "${check_job}")
+	echo_status "${check_status}"
 
-
-printf "%5s" "${score}"
-hspace 2
-export BOX_PADDING=20
-echo_verdict "${verdict}"
-
-if "${SHOW_REASON}"; then
+	printf "%5s" "${score}"
 	hspace 2
-	printf "%s" "${reason}"
+	export BOX_PADDING=20
+	echo_verdict "${verdict}"
+
+	if "${SHOW_REASON}"; then
+		hspace 2
+		printf "%s" "${reason}"
+	fi
+
+	echo
 fi
 
 echo "${score}" > "${LOGS_DIR}/${test_name}.score"
 echo "${verdict}" > "${LOGS_DIR}/${test_name}.verdict"
 echo "${execution_time}" > "${LOGS_DIR}/${test_name}.time"
-
-echo
 
 
 if "${SENSITIVE_RUN}"; then

--- a/scripts/internal/invoke_util.py
+++ b/scripts/internal/invoke_util.py
@@ -1,0 +1,36 @@
+def get_short_verdict(verdict):
+    if verdict == "Correct":
+        return "AC"
+    elif verdict == "Runtime Error":
+        return "RTE"
+    elif verdict == "Time Limit Exceeded":
+        return "TLE"
+    elif verdict == "Wrong Answer":
+        return "WA"
+    elif verdict == "Partially Correct":
+        return "OK"
+    elif verdict == "Protocol Violation":
+        return "PV"
+    else:
+        return "JE"
+
+
+def is_verdict_expected(score, verdict, expected_verdict):
+    if expected_verdict in ["correct", "model_solution"]:
+        return verdict == "Correct" and score == 1
+    elif expected_verdict == "time_limit":
+        return verdict == "Time Limit Exceeded"
+    elif expected_verdict == "memory_limit":
+        return verdict == "Runtime Error"
+    elif expected_verdict == "incorrect":
+        return verdict == "Wrong Answer"
+    elif expected_verdict == "runtime_error":
+        return verdict == "Runtime Error"
+    elif expected_verdict == "failed":
+        return verdict != "Correct" or score == 0
+    elif expected_verdict == "time_limit_and_runtime_error":
+        return verdict in ["Time Limit Exceeded", "Runtime Error"]
+    elif expected_verdict == "partially_correct":
+        return 0 < score < 1
+    else:
+        raise ValueError("Invalid verdict")

--- a/scripts/internal/solution_summary.sh
+++ b/scripts/internal/solution_summary.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "${INTERNALS}/util.sh"
+
+solution_filename="$1"; shift
+score="$1"; shift
+printf "%-30s %-5s" "${solution_filename}" "${score}"
+while [ $# -gt 0 ]; do
+  short_verdict="$1"; shift
+  short_verdict_color="$1"; shift
+  max_execution_time="$1"; shift
+
+  hspace 1
+  export BOX_PADDING=3
+  boxed_echo "${short_verdict_color}" "${short_verdict}"
+
+  hspace 1
+  printf "%-5s" "${max_execution_time}"
+done
+
+echo

--- a/scripts/internal/subtask_summary.sh
+++ b/scripts/internal/subtask_summary.sh
@@ -4,42 +4,51 @@ set -euo pipefail
 
 source "${INTERNALS}/util.sh"
 
+subtask_index="$1"; shift
 subtask_name="$1"; shift
 num_tests="$1"; shift
 
+echo -n "[${subtask_index}] "
 printf "%-${STATUS_PAD}s" "${subtask_name}"
 if [ $# -gt 0 ]; then
   num_tests_run="$1"; shift
-  max_execution_time="$1"; shift
 
   if [ "${num_tests_run}" -eq "${num_tests}" ]; then
     tests_color="ok"
+  elif [ "${num_tests_run}" -eq "0" ]; then
+    tests_color="fail"
   else
     tests_color="warn"
   fi
   export BOX_PADDING=13
   boxed_echo "${tests_color}" "${num_tests_run}/${num_tests} tests"
 
-  printf "%7s" "${max_execution_time}"
-
   if [ $# -gt 0 ]; then
-    short_verdict="$1"; shift
-    short_verdict_color="$1"; shift
-    subtask_score="$1"; shift
-    subtask_score_color="$1"; shift
-    full_subtask_score="$1"; shift
-    test_name="$1"; shift
-
+    max_execution_time="$1"; shift
     hspace 2
-    export BOX_PADDING=3
-    boxed_echo "${short_verdict_color}" "${short_verdict}"
+    printf "%7s" "${max_execution_time}"
 
-    hspace 2
-    export BOX_PADDING=13
-    boxed_echo "${subtask_score_color}" "${subtask_score}/${full_subtask_score} pts"
+    if [ $# -gt 0 ]; then
+      short_verdict="$1"; shift
+      short_verdict_color="$1"; shift
+      subtask_score="$1"; shift
+      subtask_score_color="$1"; shift
+      full_subtask_score="$1"; shift
+      test_name="$1"; shift
 
-    hspace 2
-    echo "${test_name}"
+      hspace 2
+      export BOX_PADDING=3
+      boxed_echo "${short_verdict_color}" "${short_verdict}"
+
+      hspace 2
+      export BOX_PADDING=13
+      boxed_echo "${subtask_score_color}" "${subtask_score}/${full_subtask_score} pts"
+
+      hspace 2
+      echo "${test_name}"
+    else
+      echo
+    fi
   else
     echo
   fi

--- a/scripts/internal/subtask_summary.sh
+++ b/scripts/internal/subtask_summary.sh
@@ -10,46 +10,39 @@ num_tests="$1"; shift
 printf "%-${STATUS_PAD}s" "${subtask_name}"
 if [ $# -gt 0 ]; then
   num_tests_run="$1"; shift
-  subtask_score="$1"; shift
-  full_subtask_score="$1"; shift
-  verdict="$1"; shift
-  test_name="$1"; shift
+  max_execution_time="$1"; shift
 
   if [ "${num_tests_run}" -eq "${num_tests}" ]; then
     tests_color="ok"
   else
     tests_color="warn"
   fi
-  export BOX_PADDING=11
+  export BOX_PADDING=13
   boxed_echo "${tests_color}" "${num_tests_run}/${num_tests} tests"
-  hspace 2
-  export BOX_PADDING=20
-  echo_verdict "${verdict}"
 
-  export BOX_PADDING=11
-  if [ "${subtask_score}" == "0" ] && [ "${verdict}" != "Correct" ]; then
-    subtask_score_color="fail"
-  elif [ "${subtask_score}" == "${full_subtask_score}" ]; then
-    subtask_score_color="ok"
-  else
-    subtask_score_color="warn"
-  fi
-  boxed_echo "${subtask_score_color}" "${subtask_score}/${full_subtask_score} pts"
+  printf "%7s" "${max_execution_time}"
 
-  if [ $# -gt 0 ]; then    
-    expected_verdict_message="$1"; shift
+  if [ $# -gt 0 ]; then
+    short_verdict="$1"; shift
+    short_verdict_color="$1"; shift
+    subtask_score="$1"; shift
+    subtask_score_color="$1"; shift
+    full_subtask_score="$1"; shift
+    test_name="$1"; shift
 
     hspace 2
-    export BOX_PADDING=30
-    expected_verdict_message_color="fail"
-    if [ "${expected_verdict_message}" == "match with expected" ]; then
-      expected_verdict_message_color="ok"
-    fi
-    boxed_echo "${expected_verdict_message_color}" "${expected_verdict_message}"
-  fi
+    export BOX_PADDING=3
+    boxed_echo "${short_verdict_color}" "${short_verdict}"
 
-  hspace 2
-  echo "${test_name}"
+    hspace 2
+    export BOX_PADDING=13
+    boxed_echo "${subtask_score_color}" "${subtask_score}/${full_subtask_score} pts"
+
+    hspace 2
+    echo "${test_name}"
+  else
+    echo
+  fi
 else
   boxed_echo "fail" "0/${num_tests} tests"
   echo


### PR DESCRIPTION
Print max runtime in `tps invoke` summary output.

Example output for https://github.com/ioi-2022/toki-cms-contest/tree/master/aplusb:
```
$ tps invoke solution/solution.cpp
solution            compile[OK]
checker             compile[OK]
RandomSmallAB-01    sol[OK]    0.155     check[OK]       1  [Correct]             
RandomSmallAB-02    sol[OK]    0.011     check[OK]       1  [Correct]             
RandomSmallAB-03    sol[OK]    0.010     check[OK]       1  [Correct]             
RandomAB-01         sol[OK]    0.010     check[OK]       1  [Correct]             
RandomAB-02         sol[OK]    0.011     check[OK]       1  [Correct]             
RandomAB-03         sol[OK]    0.011     check[OK]       1  [Correct]             
RandomBZero-01      sol[OK]    0.012     check[OK]       1  [Correct]             
RandomBZero-02      sol[OK]    0.011     check[OK]       1  [Correct]             
0-01                sol[OK]    0.010     check[OK]       1  [Correct]             
0-02                sol[OK]    0.012     check[OK]       1  [Correct]             
1-01                sol[OK]    0.010     check[OK]       1  [Correct]             
1-02                sol[OK]    0.010     check[OK]       1  [Correct]             
3-01                sol[OK]    0.012     check[OK]       1  [Correct]             

Subtask summary
[0] samples             [2/2 tests]        0.012  [AC]   [0/0 pts]        0-01
[1] smallAB             [7/7 tests]        0.155  [AC]   [20/20 pts]      0-01
[2] bZero               [2/2 tests]        0.012  [AC]   [30/30 pts]      RandomBZero-01
[3] full                [7/7 tests]        0.155  [AC]   [50/50 pts]      3-01
100/100 pts
All verdict matches with solutions.json
```

Also add `tps invoke-all`
```
$ tps invoke-all
checker             compile[OK]
Subtask summary
[0] samples             [2/2 tests]    
[1] smallAB             [7/7 tests]    
[2] bZero               [2/2 tests]    
[3] full                [7/7 tests]    

Run result
Filename                       Pts   [0]         [1]         [2]         [3]        
solution.cpp                   100   [AC]  0.013 [AC]  0.654 [AC]  0.014 [AC]  0.654
solution-bitwise.cpp           100   [AC]  0.013 [AC]  0.461 [AC]  0.013 [AC]  0.461
solution-b-zero.cpp            30    [WA]  0.012 [WA]  0.421 [AC]  0.012 [WA]  0.421
All verdict matches with solutions.json

Finished.
```